### PR TITLE
Add CVE PoC Search to search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,7 @@
 - [Recon-ng](https://github.com/lanmaster53/recon-ng)
 - [PublicWWW](https://publicwww.com/)
 - [FCC ID Database](https://fccid.io/)
+- [CVE PoC Search](https://labs.jamessawyer.co.uk/cves/) - Search public GitHub proof-of-concept repositories by CVE identifier
 ---
 ## Defensive Security
 


### PR DESCRIPTION
## Summary
- add CVE PoC Search to the search engines section
- keep the change limited to a single README entry